### PR TITLE
Add Interval as constant

### DIFF
--- a/src/IntervalRootFinding.jl
+++ b/src/IntervalRootFinding.jl
@@ -21,6 +21,7 @@ import Base: ⊆, show
 
 const derivative = ForwardDiff.derivative
 const D = derivative
+const Interval = IntervalArithmetic.Interval
 
 # Root object:
 immutable Root{T<:Union{Interval,IntervalBox}}

--- a/test/bisect.jl
+++ b/test/bisect.jl
@@ -1,11 +1,12 @@
 using IntervalArithmetic, IntervalRootFinding
 using Base.Test
 
+const Interval = IntervalArithmetic.Interval
 
 @testset "`bisect` function" begin
     X = 0..1
-    @test bisect(X) == (0..0.5, 0.5..1)
-    @test bisect(X, 0.25) == (0..0.25, 0.25..1)
+    @test bisect(X) == (Interval(0,0.5), Interval(0.5,1))
+    @test bisect(X, 0.25) == (Interval(0,0.25), Interval(0.25,1))
 
     X = -∞..∞
     @test bisect(X) == (-∞..0, 0..∞)
@@ -16,9 +17,9 @@ using Base.Test
 
     X = (0..1) × (0..2)
     @test bisect(X) == ( (0..1) × (0..1), (0..1) × (1..2) )
-    @test bisect(X, 0.25) == ( (0..1) × (0..0.5), (0..1) × (0.5..2) )
-    @test bisect(X, 1, 0.5) == ( (0..0.5) × (0..2), (0.5..1) × (0..2) )
-    @test bisect(X, 1, 0.25) == ( (0..0.25) × (0..2), (0.25..1) × (0..2) )
+    @test bisect(X, 0.25) == ( (0..1) × Interval(0,0.5), (0..1) × Interval(0.5,2) )
+    @test bisect(X, 1, 0.5) == ( Interval(0,0.5) × (0..2), Interval(0.5,1) × (0..2) )
+    @test bisect(X, 1, 0.25) == ( Interval(0,0.25) × (0..2), Interval(0.25,1) × (0..2) )
 
     X = (-∞..∞) × (-∞..∞)
     @test bisect(X) == ( (-∞..0) × (-∞..∞), (0..∞) × (-∞..∞))


### PR DESCRIPTION
Tests are failing after cloning because `Interval` is not being recognized. I simply solve this by adding it as a `const`