### PR TITLE
Bring back a method for 𝒩

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,13 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+
+matrix:
+  allow_failures:
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
 
 branches:
   only:

--- a/src/contractors.jl
+++ b/src/contractors.jl
@@ -71,6 +71,11 @@ function 𝒩{T}(f, f′, X::Interval{T})
     m - (f(m) / f′(X))
 end
 
+function 𝒩{T}(f, X::Interval{T}, dX::Interval{T})
+    m = Interval(mid(X, where_bisect))
+
+    m - (f(m) / dX)
+end
 
 IntervalArithmetic.mid(X::IntervalBox, α) = mid.(X, α)
 


### PR DESCRIPTION
This brings back a method for 𝒩 (which depends on the function `f` and two intervals) which was deleted when #55 was merged. It will probably not be needed once `find_roots` is deleted, but for the time being I have a case that requires it. (This method was untested previously; I haven't add any tests, but I could if it makes any sense.)