### PR TITLE
Use gauss_elimination_interval to solve A*b = x in contractors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 docs/build/
 docs/site/
-benchmark/tune.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/build/
 docs/site/
+benchmark/tune.json

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -73,3 +73,35 @@ for (k, dr) in enumerate(dr_functions)
     s["Automatic differentiation"] = @benchmarkable ForwardDiff.derivative($dr, $X)
     s["Slope expansion"] = @benchmarkable slope($dr, $X, $(mid(X)))
 end
+
+
+S = SUITE["Linear equations"] = BenchmarkGroup()
+
+sizes = (2, 5, 10)
+
+for n in sizes
+    s = S["n = $n"] = BenchmarkGroup()
+    A = Interval.(randn(n, n))
+    b = Interval.(randn(n))
+
+    s["Gauss seidel"] = @benchmarkable gauss_seidel_interval($A, $b)
+    s["Gauss seidel contractor"] = @benchmarkable gauss_seidel_contractor($A, $b)
+    s["Gauss elimination"] = @benchmarkable gauss_elimination_interval($A, $b)
+end
+
+
+S = SUITE["Dietmar-Ratz"] = BenchmarkGroup()
+X = Interval(0.75, 1.75)
+
+for (k, dr) in enumerate(dr_functions)
+    s = S["Dietmar-Ratz $k"] = BenchmarkGroup()
+
+    if k != 8  # dr8 is excluded as it has too many roots
+        for method in (Newton, Krawczyk)
+            s[string(method)] = @benchmarkable roots($dr, $X, $method, $tol)
+        end
+    end
+
+    s["Automatic differentiation"] = @benchmarkable ForwardDiff.derivative($dr, $X)
+    s["Slope expansion"] = @benchmarkable slope($dr, $X, $(mid(X)))
+end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -5,6 +5,7 @@ using BenchmarkTools
 using ForwardDiff
 using IntervalArithmetic
 using IntervalRootFinding
+using StaticArrays
 
 import Random
 
@@ -51,6 +52,8 @@ for n in sizes
     s = S["n = $n"] = BenchmarkGroup()
     A = Interval.(randn(n, n))
     b = Interval.(randn(n))
+    A = SMatrix{n, n}(A)
+    b = SVector{n}(b)
 
     s["Gauss seidel"] = @benchmarkable gauss_seidel_interval($A, $b)
     s["Gauss seidel contractor"] = @benchmarkable gauss_seidel_contractor($A, $b)

--- a/src/IntervalRootFinding.jl
+++ b/src/IntervalRootFinding.jl
@@ -38,19 +38,20 @@ const D = derivative
 
 const where_bisect = IntervalArithmetic.where_bisect ## 127//256
 
+include("complex.jl")
+include("slopes.jl")
+include("linear_eq.jl")
+include("quadratic.jl")
 
 include("root_object.jl")
 
-include("newton.jl")
-include("krawczyk.jl")
-
-include("complex.jl")
 include("contractors.jl")
 include("roots.jl")
+
+# Old stuff
+include("newton.jl")
+include("krawczyk.jl")
 include("newton1d.jl")
-include("quadratic.jl")
-include("linear_eq.jl")
-include("slopes.jl")
 
 
 gradient(f) = X -> ForwardDiff.gradient(f, X[:])

--- a/src/IntervalRootFinding.jl
+++ b/src/IntervalRootFinding.jl
@@ -8,7 +8,7 @@ using IntervalArithmetic
 using ForwardDiff
 using StaticArrays
 
-using LinearAlgebra: I, Diagonal
+using LinearAlgebra: I, diag
 
 
 import Base: ⊆, show, big, \

--- a/src/linear_eq.jl
+++ b/src/linear_eq.jl
@@ -162,5 +162,7 @@ function gauss_elimination_interval1!(x::AbstractArray, a::AbstractMatrix, b::Ab
     a \ b
 end
 
-\(A::StaticMatrix{Interval{T}}, b::StaticArray{Interval{T}}; kwargs...) where T = gauss_elimination_interval(A, b, kwargs...)
+\(A::StaticArray{Tuple{M, N}, Interval{T}, 2}, b::StaticArray{Tuple{N}, Interval{T}, 1} ; kwargs...) where {M, N, T} = gauss_elimination_interval(A, b, kwargs...)
+\(A::StaticArray{Tuple{M, N}, Interval{T}, 2}, b::IntervalBox ; kwargs...) where {M, N, T} = gauss_elimination_interval(A, b.v, kwargs...)
+
 \(A::Matrix{Interval{T}}, b::Array{Interval{T}}; kwargs...) where T = gauss_elimination_interval(A, b, kwargs...)

--- a/test/linear_eq.jl
+++ b/test/linear_eq.jl
@@ -19,13 +19,13 @@ end
 
 @testset "Linear Equations" begin
 
-    As = [[2..3 0..1; 1..2 2..3], ]
-    bs = [[0..120, 60..240], ]
-    xs = [[-120..90, -60..240], ]
+    As = Any[SMatrix{2}(2..3, 1..2, 0..1, 2..3), ]
+    bs = Any[SVector(0..120, 60..240), ]
+    xs = Any[SVector(-120..90, -60..240), ]
 
-    for i in 1:10
-        rand_A = rand_mat(i)[1]
-        rand_x = rand_vec(i)[1]
+    for i in 2:6
+        rand_A = rand_mat(i)[3]
+        rand_x = rand_vec(i)[3]
         rand_b = rand_A * rand_x
         push!(As, rand_A)
         push!(bs, rand_b)
@@ -35,7 +35,7 @@ end
     n = length(As)
 
 
-    for solver in (gauss_seidel_interval, gauss_seidel_contractor, gauss_elimination_interval, \)
+    for solver in (gauss_seidel_interval, gauss_seidel_contractor, gauss_elimination_interval)
         @testset "Solver $solver" begin
             #for precondition in (false, true)
 

--- a/test/test_smiley.jl
+++ b/test/test_smiley.jl
@@ -12,26 +12,28 @@ function test_all_unique(xs)
 end
 
 const tol = 1e-6
-const method = Newton # NOTE: Bisection method performs badly in all examples
-
-@info("Testing method $(method)")
+# NOTE: Bisection method performs badly in all examples
 
 @testset "$(SmileyExample22.title)" begin
-    roots_found = roots(SmileyExample22.f, SmileyExample22.region, method, tol)
-    @test length(roots_found) == 8
-    test_all_unique(roots_found)
-    # no reference data for roots given
+    for method in (Newton, Krawczyk)
+        roots_found = roots(SmileyExample22.f, SmileyExample22.region, method, tol)
+        @test length(roots_found) == 8
+        test_all_unique(roots_found)
+        # no reference data for roots given
+    end
 end
 
 for example in (SmileyExample52, SmileyExample54) #, SmileyExample55)
     @testset "$(example.title)" begin
-        roots_found = roots(example.f, example.region, method, tol)
-        @test length(roots_found) == length(example.known_roots)
-        test_all_unique(roots_found)
-        for rf in roots_found
-            # check there is exactly one known root for each found root
-            @test sum(!isempty(rk ∩ rf.interval)
-                    for rk in example.known_roots) == 1
+        for method in (Newton, Krawczyk)
+            roots_found = roots(example.f, example.region, method, tol)
+            @test length(roots_found) == length(example.known_roots)
+            test_all_unique(roots_found)
+            for rf in roots_found
+                # check there is exactly one known root for each found root
+                @test sum(!isempty(rk ∩ rf.interval)
+                        for rk in example.known_roots) == 1
+            end
         end
     end
 end


### PR DESCRIPTION
This PR forces the used of (preconditionned) Gauss elimination in Newton contractor.

It required some adjustement as the previous definition of the algorithm for `SArray` was incorrect. In order to stay simple, this PR drops support for vector and matrices that are neither `MArray` or `SArray`

The change result in small perfomance improvements. Unfortunately not enough to test the functions mentionned in #108 and #86 in a reasonnable amount of time, but it is a first step towards solving these issues.

Other changes:
- The benchmarks have been changed to use `SArray` rather thant `Array`.
- Due to the previous, `gauss_seidel_contractor` had to be modified to handle `SArray` efficiently.
- The Smiley tests now also test Krawczyk method.

And finally here is the benchmark report. Note that the improvements concerning the functions in `linear_eq.jl` do not give much information as the benchmarks where modified.

---
<details>
<summary>Benchmark report</summary>

# Benchmark Report for *IntervalRootFinding*

## Job Properties
* Time of benchmarks:
    - Target: 8 Feb 2019 - 01:46
    - Baseline: 8 Feb 2019 - 01:49
* Package commits:
    - Target: 91e0a4
    - Baseline: 8f605c
* Julia commits:
    - Target: 80516c
    - Baseline: 80516c
* Julia command flags:
    - Target: None
    - Baseline: None
* Environment variables:
    - Target: None
    - Baseline: None

## Results
A ratio greater than `1.0` denotes a possible regression (marked with :x:), while a ratio less
than `1.0` denotes a possible improvement (marked with :white_check_mark:). Only significant results - results
that indicate possible regressions or improvements - are shown below (thus, an empty table means that all
benchmark results remained invariant between builds).

| ID                                                                | time ratio                   | memory ratio                 |
|-------------------------------------------------------------------|------------------------------|------------------------------|
| `["Dietmar-Ratz", "Dietmar-Ratz 9", "Krawczyk"]`                  | 0.92 (5%) :white_check_mark: |                   1.00 (1%)  |
| `["Linear equations", "n = 10", "Gauss elimination"]`             | 0.61 (5%) :white_check_mark: |                1.08 (1%) :x: |
| `["Linear equations", "n = 10", "Gauss seidel contractor"]`       | 0.74 (5%) :white_check_mark: | 0.47 (1%) :white_check_mark: |
| `["Linear equations", "n = 10", "Gauss seidel"]`                  | 0.63 (5%) :white_check_mark: | 0.14 (1%) :white_check_mark: |
| `["Linear equations", "n = 2", "Gauss elimination"]`              | 0.14 (5%) :white_check_mark: | 0.17 (1%) :white_check_mark: |
| `["Linear equations", "n = 2", "Gauss seidel contractor"]`        | 0.44 (5%) :white_check_mark: | 0.06 (1%) :white_check_mark: |
| `["Linear equations", "n = 2", "Gauss seidel"]`                   | 0.31 (5%) :white_check_mark: | 0.02 (1%) :white_check_mark: |
| `["Linear equations", "n = 5", "Gauss elimination"]`              | 0.61 (5%) :white_check_mark: | 0.53 (1%) :white_check_mark: |
| `["Linear equations", "n = 5", "Gauss seidel contractor"]`        | 0.84 (5%) :white_check_mark: | 0.20 (1%) :white_check_mark: |
| `["Linear equations", "n = 5", "Gauss seidel"]`                   | 0.71 (5%) :white_check_mark: | 0.06 (1%) :white_check_mark: |
| `["Rastigrin stationary points", "Newton"]`                       | 0.83 (5%) :white_check_mark: | 0.86 (1%) :white_check_mark: |
| `["Smiley", "Smiley and Chun (2001), Example 2.2", "Newton"]`     |                   0.97 (5%)  | 0.98 (1%) :white_check_mark: |
| `["Smiley", "Smiley and Chun (2001), Example 5.2", "Newton"]`     | 0.78 (5%) :white_check_mark: | 0.83 (1%) :white_check_mark: |
| `["Smiley", "Smiley and Chun (2001), Example 5.4", "Newton"]`     |                   1.00 (5%)  |                1.01 (1%) :x: |

## Benchmark Group List
Here's a list of all the benchmark groups executed by this job:

- `["Dietmar-Ratz", "Dietmar-Ratz 1"]`
- `["Dietmar-Ratz", "Dietmar-Ratz 2"]`
- `["Dietmar-Ratz", "Dietmar-Ratz 3"]`
- `["Dietmar-Ratz", "Dietmar-Ratz 4"]`
- `["Dietmar-Ratz", "Dietmar-Ratz 5"]`
- `["Dietmar-Ratz", "Dietmar-Ratz 6"]`
- `["Dietmar-Ratz", "Dietmar-Ratz 7"]`
- `["Dietmar-Ratz", "Dietmar-Ratz 8"]`
- `["Dietmar-Ratz", "Dietmar-Ratz 9"]`
- `["Linear equations", "n = 10"]`
- `["Linear equations", "n = 2"]`
- `["Linear equations", "n = 5"]`
- `["Rastigrin stationary points"]`
- `["Smiley", "Smiley and Chun (2001), Example 2.2"]`
- `["Smiley", "Smiley and Chun (2001), Example 5.2"]`
- `["Smiley", "Smiley and Chun (2001), Example 5.4"]`

## Julia versioninfo

### Target
```
Julia Version 1.1.0
Commit 80516ca202 (2019-01-21 21:24 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
      Microsoft Windows [version 10.0.17763.292]
  CPU: Intel(R) Core(TM) i5-6600K CPU @ 3.50GHz: 
              speed         user         nice          sys         idle          irq
       #1  3504 MHz   20717015            0     12064281    136707359      2893265  ticks
       #2  3504 MHz   20986640            0      8425671    140076125       221156  ticks
       #3  3504 MHz   27314125            0      7700046    134474265       157843  ticks
       #4  3504 MHz   27567140            0      8096406    133824890       168750  ticks
       
  Memory: 15.95343017578125 GB (8450.8984375 MB free)
  Uptime: 295600.0 sec
  Load Avg:  0.0  0.0  0.0
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-6.0.1 (ORCJIT, skylake)
```

### Baseline
```
Julia Version 1.1.0
Commit 80516ca202 (2019-01-21 21:24 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
      Microsoft Windows [version 10.0.17763.292]
  CPU: Intel(R) Core(TM) i5-6600K CPU @ 3.50GHz: 
              speed         user         nice          sys         idle          irq
       #1  3504 MHz   20752468            0     12070468    136819640      2894718  ticks
       #2  3504 MHz   21026109            0      8430671    140185578       221281  ticks
       #3  3504 MHz   27361468            0      7704109    134576781       157890  ticks
       #4  3504 MHz   27616078            0      8101140    133925140       168750  ticks
       
  Memory: 15.95343017578125 GB (8412.49609375 MB free)
  Uptime: 295754.0 sec
  Load Avg:  0.0  0.0  0.0
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-6.0.1 (ORCJIT, skylake)
```

</details>