### PR TITLE
Correct multidim Krawczyk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ os:
   - osx
 
 julia:
-  - 1.1
-  - 1.2
-  - 1.3
   - 1.4
+  - 1.5
   - nightly
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,7 @@
 environment:
   matrix:
-  - julia_version: 1.1
-  - julia_version: 1.2
-  - julia_version: 1.3
   - julia_version: 1.4
+  - julia_version: 1.5
   - julia_version: nightly
 
 platform:

--- a/src/contractors.jl
+++ b/src/contractors.jl
@@ -47,11 +47,11 @@ Multi-variable Krawczyk operator.
 """
 function 𝒦(f, jacobian, X::IntervalBox{T}, α) where {T}
     m = mid(X, α)
-    mm = IntervalBox(m)
     J = jacobian(X)
-    Y = mid.(inv(jacobian(mm)))
+    Y = inv(jacobian(m))
+    mm = IntervalBox(m)
 
-    return m - Y*f(mm) + (I - Y*J) * (X.v - m)
+    return mm - Y*f(mm) + (I - Y*J) * (X - mm)
 end
 
 

--- a/src/contractors.jl
+++ b/src/contractors.jl
@@ -34,7 +34,13 @@ Single-variable Krawczyk operator.
 The symbol for the operator is accessed with `\\scrK<tab>`.
 """
 function 𝒦(f, f′, X::Interval{T}, α) where {T}
-    m = Interval(mid(X, α))
+    m = mid(X, α)
+    mm = Interval(m)
+
+    if isempty(f(mm))  # outside domain of f
+        return emptyinterval(X)
+    end
+
     Y = 1 / f′(m)
 
     return m - Y*f(m) + (1 - Y*f′(X)) * (X - m)
@@ -47,9 +53,14 @@ Multi-variable Krawczyk operator.
 """
 function 𝒦(f, jacobian, X::IntervalBox{T}, α) where {T}
     m = mid(X, α)
+    mm = IntervalBox(m)
+
+    if isempty(f(mm))  # outside domain of f
+        return emptyinterval(X)
+    end
+
     J = jacobian(X)
     Y = inv(jacobian(m))
-    mm = IntervalBox(m)
 
     return mm - Y*f(mm) + (I - Y*J) * (X - mm)
 end

--- a/src/contractors.jl
+++ b/src/contractors.jl
@@ -34,16 +34,17 @@ Single-variable Krawczyk operator.
 The symbol for the operator is accessed with `\\scrK<tab>`.
 """
 function 𝒦(f, f′, X::Interval{T}, α) where {T}
-    m = mid(X, α)
-    mm = Interval(m)
+    m = Interval(mid(X, α))
 
-    if isempty(f(mm))  # outside domain of f
+    if isempty(f(m))  # outside domain of f
         return emptyinterval(X)
     end
 
-    Y = 1 / f′(m)
+    J = f′(X)  # derivative
 
-    return m - Y*f(m) + (1 - Y*f′(X)) * (X - m)
+    Y = 1 / mid(J)
+
+    return m - Y*f(m) + (1 - Y*J) * (X - m)
 end
 
 """
@@ -52,17 +53,16 @@ end
 Multi-variable Krawczyk operator.
 """
 function 𝒦(f, jacobian, X::IntervalBox{T}, α) where {T}
-    m = mid(X, α)
-    mm = IntervalBox(m)
+    m = IntervalBox(Interval.(mid(X, α)))
 
-    if isempty(f(mm))  # outside domain of f
+    if isempty(f(m))  # outside domain of f
         return emptyinterval(X)
     end
 
     J = jacobian(X)
-    Y = inv(jacobian(m))
+    Y = inv(mid.(J))
 
-    return mm - Y*f(mm) + (I - Y*J) * (X - mm)
+    return m - Y*f(m) + (I - Y*J) * (X - m)
 end
 
 


### PR DESCRIPTION
This "corrects" multi-dimensional Krawczyk to use the inverse of a real matrix instead of an interval matrix. This should not affect correctness but should significantly improve performance.

cc @Kolaru 