### PR TITLE
Add compat with IntervalArithmetic 0.16

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 ForwardDiff = "^0.10.0"
-IntervalArithmetic = "^0.15.0"
+IntervalArithmetic = "0.15, 0.16"
 Polynomials = "0.5.0"
 StaticArrays = "^0.11.0"
 julia = "1"


### PR DESCRIPTION
I haven't tested this, but the CI should check. It would be nice to be able to use both IntervalArithmetic 0.16 and the latest release of IntervalRootFinding.jl together.