### PR TITLE
Refactor contractors

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -39,7 +39,7 @@ Newton{typeof(sin),typeof(cos)}(sin, cos)
 julia> C(Root(pi ± 0.001, :unknown), 1e-10)
 Root([3.14159, 3.1416], :unique)
 
-julia> C(Root(2 ± 0.001, :unkown), 1e-10)
+julia> C(Root(2 ± 0.001, :unknown), 1e-10)
 Root([1.99899, 2.00101], :empty)
 ```
 

--- a/src/contractors.jl
+++ b/src/contractors.jl
@@ -107,8 +107,7 @@ safe_isempty(X) = isempty(IntervalBox(X))
 """
     contract(contractor, R)
 
-Contraction operation for contractors using the first derivative of the
-function.
+Contract the region R using the given contractor.
 """
 function contract(B::Bisection, R::Root)
     X = interval(R)

--- a/src/contractors.jl
+++ b/src/contractors.jl
@@ -1,26 +1,25 @@
-export Contractor
 export Bisection, Newton, Krawczyk
 
 """
-    Contractor{F}
+    AbstractContractor{F}
 
 Abstract type for contractors.
 """
-abstract type Contractor{F} end
+abstract type AbstractContractor{F} end
 
 """
-    Bisection{F} <: Contractor{F}
+    Bisection{F} <: AbstractContractor{F}
 
-Contractor type for the bisection method.
+AbstractContractor type for the bisection method.
 """
-struct Bisection{F} <: Contractor{F}
+struct Bisection{F} <: AbstractContractor{F}
     f::F
 end
 
 """
-    Newton{F, FP} <: Contractor{F}
+    Newton{F, FP} <: AbstractContractor{F}
 
-Contractor type for the interval Newton method.
+AbstractContractor type for the interval Newton method.
 
 # Fields
     - `f::F`: function whose roots are searched
@@ -37,7 +36,7 @@ contracted interval together with its status.
     - `R`: Root object containing the interval to contract.
     - `α`: Point of bisection of intervals.
 """
-struct Newton{F, FP} <: Contractor{F}
+struct Newton{F, FP} <: AbstractContractor{F}
     f::F
     f′::FP   # use \prime<TAB> for ′
 end
@@ -55,9 +54,9 @@ function (N::Newton)(X::IntervalBox ; α=where_bisect)
 end
 
 """
-    Krawczyk{F, FP} <: Contractor{F}
+    Krawczyk{F, FP} <: AbstractContractor{F}
 
-Contractor type for the interval Krawczyk method.
+AbstractContractor type for the interval Krawczyk method.
 
 # Fields
     - `f::F`: function whose roots are searched
@@ -74,7 +73,7 @@ contracted interval together with its status.
     - `R`: Root object containing the interval to contract.
     - `α`: Point of bisection of intervals.
 """
-struct Krawczyk{F, FP} <: Contractor{F}
+struct Krawczyk{F, FP} <: AbstractContractor{F}
     f::F
     f′::FP   # use \prime<TAB> for ′
 end
@@ -169,7 +168,7 @@ end
 Wrap the refine method to leave unchanged intervals that are not guaranteed to
 contain an unique solution.
 """
-function refine(C::Contractor, R::Root, root_problem)
+function refine(C::AbstractContractor, R::Root, root_problem)
     root_status(R) != :unique && return R
     return Root(refine(C, interval(R), root_problem), :unique)
 end

--- a/src/root_object.jl
+++ b/src/root_object.jl
@@ -12,7 +12,7 @@ by the `roots` function.
 # Fields
   - `interval`: a region (either `Interval` of `IntervalBox`) searched for
         roots.
-  - `status`: the status of the region, valid values are `:empty`, `unkown` and
+  - `status`: the status of the region, valid values are `:empty`, `unknown` and
         `:unique`.
 """
 struct Root{T}

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -86,26 +86,26 @@ Inputs:
 """
 function roots(f::Function, X, contractor::Type{C}=default_contractor,
                search_order::Type{S}=default_search_order,
-               tol::Float64=default_tolerance) where {C <: Contractor, S <: SearchOrder}
+               tol::Float64=default_tolerance) where {C <: AbstractContractor, S <: SearchOrder}
 
     _roots(f, X, contractor, search_order, tol)
 end
 
 function roots(f::Function, deriv::Function, X, contractor::Type{C}=default_contractor,
                search_order::Type{S}=default_search_order,
-               tol::Float64=default_tolerance) where {C <: Contractor, S <: SearchOrder}
+               tol::Float64=default_tolerance) where {C <: AbstractContractor, S <: SearchOrder}
 
     _roots(f, deriv, X, contractor, search_order, tol)
 end
 
 function roots(f::Function, X, contractor::Type{C},
-               tol::Float64) where {C <: Contractor}
+               tol::Float64) where {C <: AbstractContractor}
 
     _roots(f, X, contractor, default_search_order, tol)
 end
 
 function roots(f::Function, deriv::Function, X, contractor::Type{C},
-               tol::Float64) where {C <: Contractor}
+               tol::Float64) where {C <: AbstractContractor}
 
     _roots(f, deriv, X, contractor, default_search_order, tol)
 end
@@ -155,13 +155,13 @@ end
 
 # Acting on `Interval`
 function _roots(f, X::Region, contractor::Type{C},
-               search_order::Type{S}, tol::Float64) where {C <: Contractor, S <: SearchOrder}
+               search_order::Type{S}, tol::Float64) where {C <: AbstractContractor, S <: SearchOrder}
 
     _roots(f, Root(X, :unknown), contractor, search_order, tol)
 end
 
 function _roots(f, deriv, X::Region, contractor::Type{C},
-               search_order::Type{S}, tol::Float64) where {C <: Contractor, S <: SearchOrder}
+               search_order::Type{S}, tol::Float64) where {C <: AbstractContractor, S <: SearchOrder}
 
     _roots(f, deriv, Root(X, :unknown), contractor, search_order, tol)
 end
@@ -169,13 +169,13 @@ end
 
 # Acting on `Vector` of `Root`
 function _roots(f, V::Vector{Root{T}}, contractor::Type{C},
-               search_order::Type{S}, tol::Float64) where {T, C <: Contractor, S <: SearchOrder}
+               search_order::Type{S}, tol::Float64) where {T, C <: AbstractContractor, S <: SearchOrder}
 
     vcat(_roots.(f, V, contractor, search_order, tol)...)
 end
 
 function _roots(f, deriv, V::Vector{Root{T}}, contractor::Type{C},
-               search_order::Type{S}, tol::Float64) where {T, C <: Contractor, S <: SearchOrder}
+               search_order::Type{S}, tol::Float64) where {T, C <: AbstractContractor, S <: SearchOrder}
 
     vcat(_roots.(f, deriv, V, contractor, search_order, tol)...)
 end
@@ -183,7 +183,7 @@ end
 
 # Acting on complex `Interval`
 function _roots(f, Xc::Complex{Interval{T}}, contractor::Type{C},
-               search_order::Type{S}, tol::Float64) where {T, C <: Contractor, S <: SearchOrder}
+               search_order::Type{S}, tol::Float64) where {T, C <: AbstractContractor, S <: SearchOrder}
 
     g = realify(f)
     Y = IntervalBox(reim(Xc)...)


### PR DESCRIPTION
This PR refactor the contractors as follow
- Separate logic of contraction and refinement of roots
- Define the contractor function directly as the contractor object

This is relatively minor and should not change any results. It is however nice to have it first before I move to overhauling the interface.