### PR TITLE
Implement `max_iteration` and `reltol` stop criterion

### DIFF
--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -136,3 +136,5 @@ The last example shows a case where the tolerance was too large to be able to is
 !!! warning
 
     For a root `x` of some function, if the absolute tolerance is smaller than `eps(x)` i.e. if `tol + x == x`, `roots` may never be able to converge to the required tolerance and the function may get stuck in an infinite loop.
+    To avoid that, either increase `abstol` or `reltol`,
+    or set a maximum number of iterations with the `max_iteration` keyword.

--- a/src/contractors.jl
+++ b/src/contractors.jl
@@ -93,7 +93,7 @@ end
 Refine a root.
 """
 function refine(root_problem::RootProblem{C}, R::Root) where C
-    root_status(R) != :unique && return R
+    root_status(R) != :unique && throw(ArgumentError("trying to refine a non unique root"))
 
     X = root_region(R)
 

--- a/src/region.jl
+++ b/src/region.jl
@@ -23,6 +23,12 @@ isnai_region(X::AbstractVector) = any(isnai, X)
 diam_region(X::Interval) = diam(X)
 diam_region(X::AbstractVector) = maximum(diam, X)
 
+mag_region(X::Interval) = mag(X)
+mag_region(X::AbstractVector) = maximum(mag, X)
+
+mig_region(X::Interval) = mig(X)
+mig_region(X::AbstractVector) = minimum(mig, X)
+
 bisect_region(X::Interval, α) = bisect(X, α)
 
 function bisect_region(X::AbstractVector, α)

--- a/src/root_object.jl
+++ b/src/root_object.jl
@@ -47,6 +47,8 @@ show(io::IO, rt::Root) = print(io, "Root($(rt.region), :$(rt.status))")
 ⊆(a::Root, b::Root) = a.region ⊆ b.region
 
 IntervalArithmetic.diam(r::Root) = diam_region(root_region(r))
+IntervalArithmetic.mag(r::Root) = mag_region(root_region(r))
+IntervalArithmetic.mig(r::Root) = mig_region(root_region(r))
 IntervalArithmetic.isnai(r::Root) = isnai_region(root_region(r))
 
 function Base.:(==)(r1::Root, r2::Root)

--- a/test/roots.jl
+++ b/test/roots.jl
@@ -287,3 +287,22 @@ end
         @test eltype(rS2) <: Root{<:SVector}
     end
 end
+
+@testset "Stop criteria" begin
+    abstols = [1e-4, 1e-7, 1e-10]
+    reltols = [1e-4, 1e-7, 1e-10]
+
+    f(x) = x*sin(1/x)
+
+    for abstol in abstols
+        for reltol in reltols
+            rts = roots(f, interval(0, 1) ; abstol, reltol)
+            regions = [rt.region for rt in rts if root_status(rt) == :unknown]
+
+            @test all(
+                (diam.(regions) .< abstol) .|
+                (diam.(regions) .< (reltol .* mag.(regions)))
+            )
+        end
+    end
+end

--- a/test/roots.jl
+++ b/test/roots.jl
@@ -305,4 +305,9 @@ end
             )
         end
     end
+
+    for max_iteration in [10, 100, 1000, 10_000]
+        rts = roots(f, interval(0, 1) ; abstol = 1e-10, max_iteration)
+        @test length(rts) <= max_iteration
+    end
 end


### PR DESCRIPTION
Add support for two new keyword in the `roots` function and the `RootProblem` struct.

Fix #66 
Fix #178 