### PR TITLE
Implement continuing processing on error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 BranchAndPrune = "0.2.1"
 ForwardDiff = "0.10, 1"
-IntervalArithmetic = "0.22.13, 0.23, 1"
+IntervalArithmetic = "1.0.3"
 Reexport = "1"
 StaticArrays = "1"
 julia = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,10 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
-[sources.IntervalRootFinding]
-path = ".."
+[sources]
+IntervalRootFinding = {path = ".."}

--- a/docs/src/decorations.md
+++ b/docs/src/decorations.md
@@ -40,7 +40,7 @@ For example, `0.1` is famously not parsed as `0.1`,
 as `0.1` can not be represented exactly as a binary number
 (just like `1/3` can not be represented exactly as a decimal number).
 
-```julia-repl
+```jldoctest
 julia> big(0.1)
 0.1000000000000000055511151231257827021181583404541015625
 ```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,3 +1,8 @@
+```@meta
+DocTestSetup = quote
+    using IntervalArithmetic, IntervalArithmetic.Symbols, IntervalRootFinding
+end
+```
 # Internals
 
 This section describes some of the internal mechanism of the package and several ways to use them to customize a search.
@@ -37,14 +42,14 @@ The contractors are various methods to guarantee and refine the
 status of a root.
 The available contractors are `Bisection`, `Newton` or `Krawczyk`.
 
-```julia-repl
-julia> using IntervalArithmetic.Symbols
+```jldoctest
+julia> using IntervalRootFinding: contract
 
 julia> contract(Newton, sin, cos, Root(pi ± 0.001, :unknown))
-Root([3.14159, 3.1416]_com, :unique)
+Root([3.14159, 3.14159]_com, :unique)
 
 julia> contract(Newton, sin, cos, Root(2 ± 0.001, :unknown))
-Root([1.99899, 2.00101]_com, :empty)
+Root([1.999, 2.001]_com, :empty)
 ```
 
 ## RootProblem and search object
@@ -58,11 +63,12 @@ for example to log information at each iteration.
 For example, the following stops the search after 15 iterations and
 shows the state of the search at that point.
 
-```julia-repl
+```jldoctest
 julia> f(x) = exp(x) - sin(x)
 f (generic function with 1 method)
 
 julia> problem = RootProblem(f, interval(-10, 10))
+RootProblem{Newton, typeof(f), IntervalRootFinding.var"#9#11"{typeof(f)}, Root{Interval{Float64}}, BranchAndPrune.BreadthFirst, Float64}(Newton, f, IntervalRootFinding.var"#9#11"{typeof(f)}(f), Root([-10.0, 10.0]_com, :unkown), BranchAndPrune.BreadthFirst, 1.0e-7, 0.0, 100000, 0.49609375, true)
 
 julia> state = nothing   # stores current state of the search
 
@@ -76,12 +82,16 @@ Branching
 └─ Branching
    ├─ Branching
    │  ├─ Branching
-   │  │  ├─ (:working, Root([-10.0, -8.7886]_com, :unknown))
-   │  │  └─ (:working, Root([-8.78861, -7.55813]_com, :unknown))
-   │  └─ (:final, Root([-6.28132, -6.28131]_com, :unique))
+   │  │  ├─ (:working, Root([-10.0, -8.78861]_com, :unknown)
+   │  │  │      Not converged: the root is still being processed)
+   │  │  └─ (:working, Root([-8.78861, -7.55814]_com, :unknown)
+   │  │         Not converged: the root is still being processed)
+   │  └─ (:final, Root([-6.28131, -6.28131]_com, :unique))
    └─ Branching
-      ├─ (:working, Root([-5.07783, -3.84734]_com, :unknown))
-      └─ (:working, Root([-3.84736, -2.5975]_com, :unknown))
+      ├─ (:working, Root([-5.07782, -3.84735]_com, :unknown)
+      │      Not converged: the root is still being processed)
+      └─ (:working, Root([-3.84735, -2.5975]_com, :unknown)
+             Not converged: the root is still being processed)
 ```
 
 The elements of the iteration are `SearchState` from the `BranchAndPrune.jl`

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -68,7 +68,15 @@ julia> f(x) = exp(x) - sin(x)
 f (generic function with 1 method)
 
 julia> problem = RootProblem(f, interval(-10, 10))
-RootProblem{Newton, typeof(f), IntervalRootFinding.var"#9#11"{typeof(f)}, Root{Interval{Float64}}, BranchAndPrune.BreadthFirst, Float64}(Newton, f, IntervalRootFinding.var"#9#11"{typeof(f)}(f), Root([-10.0, 10.0]_com, :unkown), BranchAndPrune.BreadthFirst, 1.0e-7, 0.0, 100000, 0.49609375, true)
+RootProblem
+  Contractor: Newton
+  Function: f
+  Search region: [-10.0, 10.0]_com
+  Search order: BranchAndPrune.BreadthFirst
+  Absolute tolerance: 1.0e-7
+  Relative tolerance: 0.0
+  Maximum iterations: 100000
+  Bisect on error: true
 
 julia> state = nothing   # stores current state of the search
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -76,7 +76,7 @@ RootProblem
   Absolute tolerance: 1.0e-7
   Relative tolerance: 0.0
   Maximum iterations: 100000
-  Bisect on error: true
+  Ignored errors: DataType[IntervalArithmetic.InconclusiveBooleanOperation]
 
 julia> state = nothing   # stores current state of the search
 

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -1,3 +1,8 @@
+```@meta
+DocTestSetup = quote
+    using IntervalArithmetic, IntervalArithmetic.Symbols, IntervalRootFinding, BenchmarkTools
+end
+```
 # `roots` interface
 
 ## Methods
@@ -11,18 +16,19 @@ Both the Newton and Krawczyk methods can determine if a root is unique in an int
 
 The method used is given using the `contractor` keyword argument:
 
-```julia-repl
+```jldoctest
 julia> roots(log, -2..2 ; contractor = Newton)
 1-element Vector{Root{Interval{Float64}}}:
- Root([0.999999, 1.00001]_com, :unique)
+ Root([1.0, 1.0]_com, :unique)
 
 julia> roots(log, -2..2 ; contractor = Krawczyk)
 1-element Vector{Root{Interval{Float64}}}:
- Root([0.999999, 1.00001]_com, :unique)
+ Root([1.0, 1.0]_com, :unique)
 
 julia> roots(log, -2..2 ; contractor = Bisection)
 1-element Vector{Root{Interval{Float64}}}:
- Root([0.999999, 1.00001]_com, :unknown)
+ Root([1.0, 1.0]_com, :unknown)
+    Not converged: region size smaller than the tolerance
 ```
 
 Note that as shown in the example, the `log` function does not complain about being given an interval going outside of its domain. While this may be surprising, this is the expected behavior and no root will ever be found outside the domain of a function.
@@ -31,14 +37,14 @@ Note that as shown in the example, the `log` function does not complain about be
 
 Newton and Krawczyk methods require the function to be differentiable, but the derivative is usually computed automatically using forward-mode automatic differentiation, provided by the `ForwardDiff.jl` package. It is however possible to provide the derivative explicitly using the `derivative` keyword argument:
 
-```julia-repl
+```jldoctest
 julia> roots(log, -2..2 ; contractor = Newton, derivative = x -> 1/x)
 1-element Vector{Root{Interval{Float64}}}:
- Root([0.999999, 1.00001]_com_NG, :unique)
+ Root([1.0, 1.0]_com_NG, :unique)
 
 julia> roots(log, -2..2 ; contractor = Krawczyk, derivative = x -> 1/x)
 1-element Vector{Root{Interval{Float64}}}:
- Root([0.999999, 1.00001]_com_NG, :unique)
+ Root([1.0, 1.0]_com_NG, :unique)
 ```
 
 When providing the derivative explicitly, the computation is expected to be slightly faster, but the precision of the result is unlikely to be affected.
@@ -47,50 +53,50 @@ When providing the derivative explicitly, the computation is expected to be slig
 julia> using BenchmarkTools
 
 julia> @btime roots(log, -2..2 ; derivative = x -> 1/x)
-  4.814 μs (53 allocations: 3.16 KiB)
+  7.050 μs (129 allocations: 9.33 KiB)
 1-element Vector{Root{Interval{Float64}}}:
- Root([0.999999, 1.00001]_com_NG, :unique)
+ Root([1.0, 1.0]_com_NG, :unique)
 
 julia> @btime roots(log, -2..2)
-  5.767 μs (53 allocations: 3.16 KiB)
+  7.743 μs (129 allocations: 9.33 KiB)
 1-element Vector{Root{Interval{Float64}}}:
- Root([0.999999, 1.00001]_com, :unique)
+ Root([1.0, 1.0]_com, :unique)
 ```
 
 This may be useful in some special cases where `ForwardDiff.jl` is unable to compute the derivative of a function. Examples are complex functions and functions whose interval extension must be manually defined (e.g. special functions like `zeta`).
 
 In dimension greater than one, the derivative can be given as a function returning the Jacobi matrix:
 
-```julia-repl
+```jldoctest
 julia> f( (x, y) ) = [sin(x), cos(y)]
 f (generic function with 1 method)
 
 julia> df( (x, y) ) = [cos(x) 0 ; 0 -sin(y)]
+df (generic function with 1 method)
 
 julia> roots(f, [-3..3, -3..3] ; derivative = df)
 2-element Vector{Root{Vector{Interval{Float64}}}}:
- Root(Interval{Float64}[[-1.24409e-21, 1.0588e-22]_com_NG, [-1.5708, -1.57079]_com_NG], :unique)
- Root(Interval{Float64}[[-1.24409e-21, 1.0588e-22]_com_NG, [1.57079, 1.5708]_com_NG], :unique)
+ Root(Interval{Float64}[[-1.28378e-21, 1.58819e-22]_com_NG, [-1.5708, -1.5708]_com_NG], :unique)
+ Root(Interval{Float64}[[-1.28378e-21, 1.58819e-22]_com_NG, [1.5708, 1.5708]_com_NG], :unique)
 ```
 
 ## Tolerance
 
 An absolute tolerance for the search may be specified as the `abstol` keyword argument.
-Currently a method must first be provided in order to be able to choose the tolerance.
 
-```julia-repl
+```jldoctest
 julia> g(x) = sin(exp(x))
 g (generic function with 1 method)
 
 julia> roots(g, 0..2)
 2-element Vector{Root{Interval{Float64}}}:
- Root([1.14472, 1.14474]_com, :unique)
- Root([1.83787, 1.83788]_com, :unique)
+ Root([1.14473, 1.14473]_com, :unique)
+ Root([1.83788, 1.83788]_com, :unique)
 
 julia> roots(g, 0..2 ; abstol = 1e-1)
 2-element Vector{Root{Interval{Float64}}}:
  Root([1.14173, 1.15244]_com, :unique)
- Root([1.78757, 1.84273]_com, :unique)
+ Root([1.78757, 1.84272]_com, :unique)
 ```
 
 A lower tolerance may greatly reduce the computation time, at the cost of an increased number of returned roots having `:unknown` status:
@@ -100,31 +106,38 @@ julia> h(x) = cos(x) * sin(1 / x)
 h (generic function with 1 method)
 
 julia> @btime roots(h, 0.05..1)
-  79.500 μs (301 allocations: 13.97 KiB)
+  484.488 μs (12218 allocations: 590.76 KiB)
 6-element Vector{Root{Interval{Float64}}}:
  Root([0.0530516, 0.0530517]_com_NG, :unique)
- Root([0.0636619, 0.063662]_com_NG, :unique)
- Root([0.0795774, 0.0795775]_com_NG, :unique)
- Root([0.106103, 0.106104]_com_NG, :unique)
- Root([0.159154, 0.159156]_com_NG, :unique)
- Root([0.318309, 0.31831]_com_NG, :unique)
+ Root([0.063662, 0.063662]_com_NG, :unique)
+ Root([0.0795775, 0.0795775]_com_NG, :unique)
+ Root([0.106103, 0.106103]_com_NG, :unique)
+ Root([0.159155, 0.159155]_com_NG, :unique)
+ Root([0.31831, 0.31831]_com_NG, :unique)
 
 julia> @btime roots(h, 0.05..1 ; abstol = 1e-2)
-  48.500 μs (265 allocations: 11.61 KiB)
+  249.720 μs (6141 allocations: 297.80 KiB)
 6-element Vector{Root{Interval{Float64}}}:
- Root([0.0514445, 0.0531087]_com_NG, :unique)
- Root([0.0570253, 0.0641615]_com, :unknown)
+ Root([0.0514446, 0.0531086]_com_NG, :unique)
+ Root([0.0570254, 0.0641614]_com, :unknown)
+    Not converged: region size smaller than the tolerance
  Root([0.0785458, 0.0797797]_com_NG, :unknown)
- Root([0.104754, 0.107542]_com_NG, :unknown)
- Root([0.157236, 0.165989]_com_NG, :unknown)
- Root([0.31716, 0.319318]_com_NG, :unique)
+    Not converged: region size smaller than the tolerance
+ Root([0.104755, 0.107541]_com_NG, :unknown)
+    Not converged: region size smaller than the tolerance
+ Root([0.157236, 0.165988]_com_NG, :unknown)
+    Not converged: region size smaller than the tolerance
+ Root([0.317161, 0.319318]_com_NG, :unique)
 
 julia> @btime roots(h, 0.05..1 ; abstol = 1e-1)
-  17.300 μs (114 allocations: 5.16 KiB)
+  66.330 μs (1402 allocations: 69.10 KiB)
 3-element Vector{Root{Interval{Float64}}}:
- Root([0.04999999, 0.107542]_com, :unknown)
- Root([0.107541, 0.165989]_com, :unknown)
- Root([0.283803, 0.356099]_com_NG, :unknown)
+ Root([0.05, 0.107541]_com, :unknown)
+    Not converged: region size smaller than the tolerance
+ Root([0.107541, 0.165988]_com, :unknown)
+    Not converged: region size smaller than the tolerance
+ Root([0.283804, 0.356099]_com_NG, :unknown)
+    Not converged: region size smaller than the tolerance
 ```
 
 The last example shows a case where the tolerance was too large to be able to isolate the roots in distinct regions.
@@ -134,3 +147,42 @@ The last example shows a case where the tolerance was too large to be able to is
     For a root `x` of some function, if the absolute tolerance is smaller than `eps(x)` i.e. if `tol + x == x`, `roots` may never be able to converge to the required tolerance and the function may get stuck in an infinite loop.
     To avoid that, either increase `abstol` or `reltol`,
     or set a maximum number of iterations with the `max_iteration` keyword.
+
+## Error during computation
+
+By default, the `roots` function will ignore errors
+and continue bisecting the given interval,
+hoping to eventually find regions that are small enough to avoid the error.
+
+This is particularly useful when using code that is using comparisons,
+which are ill-defined for intervals
+(see [the IntervalArithmetic.jl documentation](https://juliaintervals.github.io/IntervalArithmetic.jl/stable/manual/usage/#Comparisons)
+for more information).
+
+For example, the following will find all roots,
+and flag the erroring singularity:
+```jldoctest bisect_on_error
+julia> f(x) = x > 2 ? 7 - x : x
+f (generic function with 1 method)
+
+julia> roots(f, -10 .. 10)
+3-element Vector{Root{Interval{Float64}}}:
+ Root([0.0, 0.0]_com, :unique)
+ Root([2.0, 2.0]_com, :unknown)
+    Not converged: region size smaller than the tolerance
+    Warning: an error was encountered during computation
+ Root([7.0, 7.0]_com_NG, :unique)
+```
+
+This behavior can be deactivated by setting `bisect_on_error` to false,
+interrupting the process as soon as an error is encountered.
+This is notably useful while debugging your code.
+
+```julia-repl
+julia> roots(f, -10 .. 10 ; bisect_on_error = false)
+ERROR: ArgumentError: `<` is purposely not supported for overlapping intervals. See instead `strictprecedes`
+```
+
+!!! warning
+
+    This behavior is considered experimental and subject to change.

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -1,6 +1,6 @@
 ```@meta
 DocTestSetup = quote
-    using IntervalArithmetic, IntervalArithmetic.Symbols, IntervalRootFinding, BenchmarkTools
+    using IntervalArithmetic, IntervalArithmetic.Symbols, IntervalRootFinding
 end
 ```
 # `roots` interface

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -182,6 +182,7 @@ so that the process is interrupted as soon as an error is encountered.
 This is useful while debugging your code.
 
 ```julia-repl
-julia> roots(f, -10 .. 10 ; ignored_errors = [])
-ERROR: ArgumentError: `<` is purposely not supported for overlapping intervals. See instead `strictprecedes`
+julia> roots(f, -10..10, ; ignored_errors = [])
+ERROR: InconclusiveBooleanOperation: The operation `[2.0, 2.0]_com_NG < [-10.0, 10.0]_com` cannot be determined unambiguously. See the documentation for more information. See also `strictprecedes`.
+Stacktrace: [..]
 ```

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -170,7 +170,8 @@ julia> roots(f, -10 .. 10)
  Root([0.0, 0.0]_com, :unique)
  Root([2.0, 2.0]_com, :unknown)
     Not converged: region size smaller than the tolerance
-    Warning: an error was encountered during computation
+    Warning: error encountered during computation (use showerror(root.error) to see the whole stacktrace)
+      InconclusiveBooleanOperation: The operation `[2.0, 2.0]_com_NG < [2.0, 2.0]_com` cannot be determined unambiguously. See the documentation for more information. See also `strictprecedes`.
  Root([7.0, 7.0]_com_NG, :unique)
 ```
 

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -150,11 +150,11 @@ The last example shows a case where the tolerance was too large to be able to is
 
 ## Error during computation
 
-By default, the `roots` function will ignore errors
-and continue bisecting the given interval,
+By default, the `roots` function will ignore `IntervalArithmetic.InconclusiveBooleanOperation`
+errors and continue bisecting the given interval,
 hoping to eventually find regions that are small enough to avoid the error.
 
-This is particularly useful when using code that is using comparisons,
+This is useful when using code that is using comparisons,
 which are ill-defined for intervals
 (see [the IntervalArithmetic.jl documentation](https://juliaintervals.github.io/IntervalArithmetic.jl/stable/manual/usage/#Comparisons)
 for more information).
@@ -174,15 +174,13 @@ julia> roots(f, -10 .. 10)
  Root([7.0, 7.0]_com_NG, :unique)
 ```
 
-This behavior can be deactivated by setting `bisect_on_error` to false,
-interrupting the process as soon as an error is encountered.
-This is notably useful while debugging your code.
+This behavior can be controlled by changing the `ignored_errors` field.
+
+To deactivate it, change it to an empty list,
+so that the process is interrupted as soon as an error is encountered.
+This is useful while debugging your code.
 
 ```julia-repl
-julia> roots(f, -10 .. 10 ; bisect_on_error = false)
+julia> roots(f, -10 .. 10 ; ignored_errors = [])
 ERROR: ArgumentError: `<` is purposely not supported for overlapping intervals. See instead `strictprecedes`
 ```
-
-!!! warning
-
-    This behavior is considered experimental and subject to change.

--- a/src/contractors.jl
+++ b/src/contractors.jl
@@ -105,5 +105,5 @@ function refine(root_problem::RootProblem{C}, R::Root) where C
         X = NX
     end
 
-    return Root(X, :unique)
+    return Root(X, :unique, :converged)
 end

--- a/src/contractors.jl
+++ b/src/contractors.jl
@@ -3,6 +3,7 @@ function image_contains_zero(f, R::Root)
     R.status == :empty && return Root(X, :empty)
 
     imX = f(X)
+    size(imX) != size(X) && throw(DimensionMismatch("input and output dimensions of f must be the same"))
 
     if !(all(in_interval.(0, imX))) || isempty_region(imX)
         return Root(X, :empty)

--- a/src/contractors.jl
+++ b/src/contractors.jl
@@ -58,7 +58,7 @@ function contract(::Type{Krawczyk}, f, derivative, X::AbstractVector)
     return mm - Y*f(mm) + (interval(I) - Y*J) * (X - mm)
 end
 
-function contract(::Type{C}, f, derivative, R::Root) where {C <: AbstractContractor}
+function contract(::Type{C}, f::F, derivative::Fp, R::Root) where {C <: AbstractContractor, F, Fp}
     # We first check with the simple bisection method
     # If we can prove it is empty at this point, we don't go further
     R2 = image_contains_zero(f, R)

--- a/src/root_object.jl
+++ b/src/root_object.jl
@@ -16,7 +16,7 @@ the `roots` function.
         and `:unique`.
   - `convergence`: the convergence status of the region. It is always `:converged`
         for roots with status `:unique`,
-        and can be either `:max_iter` or `:tolerance` for roots with status `:unknown`,
+        and can be either `:max_iterartion` or `:tolerance` for roots with status `:unknown`,
         depending on whether they stopped being processing due to reaching
         the maximum number of iteration or the tolerance, respectively.
   - `errored`: whether an error was encounter during the processing of this region.
@@ -60,8 +60,10 @@ function show(io::IO, rt::Root)
     if rt.status == :unknown
         if rt.convergence == :tolerance
             print(io, "\n    Not converged: region size smaller than the tolerance")
-        elseif rt.convergence == :max_iter 
+        elseif rt.convergence == :max_iterartion 
             print(io, "\n    Not converged: reached maximal number of iterations")
+        elseif rt.convergence == :none
+            print(io, "\n    Not converged: the root is still being processed")
         else
             print(io, "\n    Not converged: unknown reason $(rt.convergence)")
         end

--- a/src/root_object.jl
+++ b/src/root_object.jl
@@ -67,7 +67,7 @@ function show(io::IO, rt::Root)
         end
 
         if rt.errored
-            print(io, "\n    Warning: an error was encountered in during computation")
+            print(io, "\n    Warning: an error was encountered during computation")
         end
     end
 end

--- a/src/root_object.jl
+++ b/src/root_object.jl
@@ -19,9 +19,8 @@ the `roots` function.
         and can be either `:max_iterartion` or `:tolerance` for roots with status `:unknown`,
         depending on whether they stopped being processing due to reaching
         the maximum number of iteration or the tolerance, respectively.
-  - `errored`: whether an error was encounter during the processing of this region.
-        Errors can be raised explicitly when encountered by setting
-        `bisect_on_error` to `flase` in the RootProblem.
+  - `errored`: whether an error was encounter but ignored during the processing of this region.
+        The ignored errors are controlled by the `ignored_errors` field of the `RootProblem`.
 """
 struct Root{T}
     region::T

--- a/src/root_object.jl
+++ b/src/root_object.jl
@@ -19,18 +19,19 @@ the `roots` function.
         and can be either `:max_iterartion` or `:tolerance` for roots with status `:unknown`,
         depending on whether they stopped being processing due to reaching
         the maximum number of iteration or the tolerance, respectively.
-  - `errored`: whether an error was encounter but ignored during the processing of this region.
+  - `error`: an error that was encounter but ignored during the processing of this region.
+        Set to `nothing` if no error was encountered.
         The ignored errors are controlled by the `ignored_errors` field of the `RootProblem`.
 """
 struct Root{T}
     region::T
     status::Symbol
     convergence::Symbol
-    errored::Bool
+    error
 end
 
-function Root(region, status::Symbol, convergence = :none, errored = false)
-    return Root(region, status, convergence, errored)
+function Root(region, status::Symbol, convergence = :none, error = nothing)
+    return Root(region, status, convergence, error)
 end
 
 """
@@ -67,11 +68,15 @@ function show(io::IO, rt::Root)
             print(io, "\n    Not converged: unknown reason $(rt.convergence)")
         end
 
-        if rt.errored
-            print(io, "\n    Warning: an error was encountered during computation")
+        if !isnothing(rt.error)
+            print(io, "\n    Warning: error encountered during computation (use showerror(root.error) to see the whole stacktrace)\n      ")
+            showerror(io, rt.error[1])
         end
     end
 end
+
+Base.showerror(io::IO, rt::Root) = showerror(io, rt.error...)
+Base.showerror(rt::Root) = showerror(stdout, rt.error...)
 
 ⊆(a::Interval, b::Root) = a ⊆ b.region
 ⊆(a::Root, b::Root) = a.region ⊆ b.region

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -12,6 +12,25 @@ struct RootProblem{C, F, G, R, S, T}
     max_iteration::Int
     where_bisect::T
     bisect_on_error::Bool
+
+    function RootProblem(
+            contractor::Type{C},
+            f::F,
+            derivative::G,
+            initial_root::R,
+            search_order::Type{S},
+            abstol::T,
+            reltol::T,
+            max_iteration::Int,
+            where_bisect::T,
+            bisect_on_error::Bool) where {C, F, G, R, S, T}
+
+        X = root_region(initial_root)
+        size(X) != size(f(X)) && throw(DimensionMismatch("input and output dimensions of f must be the same"))
+        return new{C, F, G, R, S, T}(
+            contractor, f, derivative, initial_root, search_order, abstol, reltol,
+            max_iteration, where_bisect, bisect_on_error)
+    end
 end
 
 """

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -13,24 +13,24 @@ struct RootProblem{C, F, G, R, S, T}
     where_bisect::T
     bisect_on_error::Bool
 
-    function RootProblem(
-            contractor::Type{C},
-            f::F,
-            derivative::G,
-            initial_root::R,
-            search_order::Type{S},
-            abstol::T,
-            reltol::T,
-            max_iteration::Int,
-            where_bisect::T,
-            bisect_on_error::Bool) where {C, F, G, R, S, T}
+    # function RootProblem(
+    #         contractor::Type{C},
+    #         f::F,
+    #         derivative::G,
+    #         initial_root::R,
+    #         search_order::Type{S},
+    #         abstol::T,
+    #         reltol::T,
+    #         max_iteration::Int,
+    #         where_bisect::T,
+    #         bisect_on_error::Bool) where {C, F, G, R, S, T}
 
-        X = root_region(initial_root)
-        size(X) != size(f(X)) && throw(DimensionMismatch("input and output dimensions of f must be the same"))
-        return new{C, F, G, R, S, T}(
-            contractor, f, derivative, initial_root, search_order, abstol, reltol,
-            max_iteration, where_bisect, bisect_on_error)
-    end
+    #     X = root_region(initial_root)
+    #     size(X) != size(f(X)) && throw(DimensionMismatch("input and output dimensions of f must be the same"))
+    #     return new{C, F, G, R, S, T}(
+    #         contractor, f, derivative, initial_root, search_order, abstol, reltol,
+    #         max_iteration, where_bisect, bisect_on_error)
+    # end
 end
 
 """
@@ -138,7 +138,8 @@ function process(root_problem, root::Root)
     if root_problem.bisect_on_error
         try
             contracted = contract(root_problem, root)
-        catch
+        catch err
+            (err isa DimensionMismatch) && rethrow()
             contracted = Root(root.region, :unknown, :none, true)
         end
     else

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -12,25 +12,6 @@ struct RootProblem{C, F, G, R, S, T}
     max_iteration::Int
     where_bisect::T
     bisect_on_error::Bool
-
-    # function RootProblem(
-    #         contractor::Type{C},
-    #         f::F,
-    #         derivative::G,
-    #         initial_root::R,
-    #         search_order::Type{S},
-    #         abstol::T,
-    #         reltol::T,
-    #         max_iteration::Int,
-    #         where_bisect::T,
-    #         bisect_on_error::Bool) where {C, F, G, R, S, T}
-
-    #     X = root_region(initial_root)
-    #     size(X) != size(f(X)) && throw(DimensionMismatch("input and output dimensions of f must be the same"))
-    #     return new{C, F, G, R, S, T}(
-    #         contractor, f, derivative, initial_root, search_order, abstol, reltol,
-    #         max_iteration, where_bisect, bisect_on_error)
-    # end
 end
 
 """
@@ -216,7 +197,7 @@ function roots(f, region ; kwargs...)
     rts = vcat(result.final_regions, result.unfinished_regions)
     return map(rts) do rt
         if rt.status == :unknown && rt.convergence == :none
-            return Root(rt.region, rt.status, :max_iter, rt.errored)
+            return Root(rt.region, rt.status, :max_iterartion, rt.errored)
         end
         return rt
     end

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -90,6 +90,18 @@ function RootProblem(
     )
 end
 
+Base.show(io::IO, pb::RootProblem) = print(io, """
+    RootProblem
+      Contractor: $(pb.contractor)
+      Function: $(pb.f)
+      Search region: $(root_region(pb.region))
+      Search order: $(pb.search_order)
+      Absolute tolerance: $(pb.abstol)
+      Relative tolerance: $(pb.reltol)
+      Maximum iterations: $(pb.max_iteration)
+      Bisect on error: $(pb.bisect_on_error)"""
+)
+
 function Base.iterate(root_problem::RootProblem, state = nothing)
     if isnothing(state)
         search = root_search(root_problem)

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -137,10 +137,6 @@ function process(root_problem, root::Root)
         contracted = Root(root.region, :unknown, :none, true)
     end
 
-    if contracted.errored
-        @info "Errored"
-    end
-
     status = root_status(contracted)
 
     if status == :unique

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -134,7 +134,7 @@ function process(root_problem, root::Root)
         contracted = contract(root_problem, root)
     catch err
         !any(isa(err, Err) for Err in root_problem.ignored_errors) && rethrow()
-        contracted = Root(root.region, :unknown, :none, true)
+        contracted = Root(root.region, :unknown, :none, (err, backtrace()))
     end
 
     status = root_status(contracted)
@@ -153,7 +153,7 @@ function process(root_problem, root::Root)
         end
 
         if under_tolerance(root_problem, contracted)
-            return :store, Root(contracted.region, :unknown, :tolerance, contracted.errored)
+            return :store, Root(contracted.region, :unknown, :tolerance, contracted.error)
         end
         
         return :branch, root
@@ -207,7 +207,7 @@ function roots(f, region ; kwargs...)
     rts = vcat(result.final_regions, result.unfinished_regions)
     return map(rts) do rt
         if rt.status == :unknown && rt.convergence == :none
-            return Root(rt.region, rt.status, :max_iterartion, rt.errored)
+            return Root(rt.region, rt.status, :max_iterartion, rt.error)
         end
         return rt
     end

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -11,7 +11,7 @@ struct RootProblem{C, F, G, R, S, T}
     reltol::T
     max_iteration::Int
     where_bisect::T
-    bisect_on_error::Bool
+    ignored_errors::Vector{DataType}
 end
 
 """
@@ -50,9 +50,10 @@ Parameters
     bisecting exactly on zero when starting with symmetrical regions,
     often leading to having a solution directly on the boundary of a region,
     which prevent the contractor to prove it's unicity. Default: `127/256`.
--`bisect_on_error`: Whether a region that errors when the function is applied to
-    to it should be bisected. If false, when an error happen, the root search is
-    interrupted. Default: true.
+-`ignored_errors`: List of exceptions that are ignored during the processing
+    of a region. If the error is encoutered, it is discarded and the region is bisected
+    further.
+    Default: `[IntervalArithmetic.InconclusiveBooleanOperation]`.
 """
 RootProblem(f, region ; kwargs...) = RootProblem(f, Root(region, :unkown) ; kwargs...)
 
@@ -65,7 +66,7 @@ function RootProblem(
         reltol = 0.0,
         max_iteration = 100_000,
         where_bisect = 0.49609375,  # 127//256
-        bisect_on_error = true)
+        ignored_errors = [IntervalArithmetic.InconclusiveBooleanOperation])
     
     N = length(root_region(root))
     if isnothing(derivative)
@@ -86,7 +87,7 @@ function RootProblem(
         reltol,
         max_iteration,
         where_bisect,
-        bisect_on_error
+        convert(Vector{DataType}, ignored_errors)
     )
 end
 
@@ -99,7 +100,7 @@ Base.show(io::IO, pb::RootProblem) = print(io, """
       Absolute tolerance: $(pb.abstol)
       Relative tolerance: $(pb.reltol)
       Maximum iterations: $(pb.max_iteration)
-      Bisect on error: $(pb.bisect_on_error)"""
+      Ignored errors: $(pb.ignored_errors)"""
 )
 
 function Base.iterate(root_problem::RootProblem, state = nothing)
@@ -128,15 +129,16 @@ function under_tolerance(root_problem, root::Root)
 end
 
 function process(root_problem, root::Root)
-    if root_problem.bisect_on_error
-        try
-            contracted = contract(root_problem, root)
-        catch err
-            (err isa DimensionMismatch) && rethrow()
-            contracted = Root(root.region, :unknown, :none, true)
-        end
-    else
+    contracted = nothing
+    try
         contracted = contract(root_problem, root)
+    catch err
+        !any(isa(err, Err) for Err in root_problem.ignored_errors) && rethrow()
+        contracted = Root(root.region, :unknown, :none, true)
+    end
+
+    if contracted.errored
+        @info "Errored"
     end
 
     status = root_status(contracted)

--- a/test/roots.jl
+++ b/test/roots.jl
@@ -296,7 +296,7 @@ end
 
     for abstol in abstols
         for reltol in reltols
-            rts = roots(f, interval(0, 1) ; abstol, reltol)
+            rts = roots(f, interval(0, 1) ; abstol, reltol, max_iteration = typemax(Int))
             regions = [rt.region for rt in rts if root_status(rt) == :unknown]
 
             @test all(

--- a/test/roots.jl
+++ b/test/roots.jl
@@ -372,3 +372,19 @@ end
         @test all(isequal_interval.(myroots, unroots))
     end
 end
+
+@testset "Bisect on error" begin
+    f(x) = x == 1 ? error() : x
+    
+    rts = roots(f, interval(-10, 10))
+    @test length(rts) == 2
+    @test rts[1].status == :unique
+    @test rts[1].convergence == :converged
+    @test !rts[1].errored
+
+    @test rts[2].status == :unknown
+    @test rts[2].convergence == :tolerance
+    @test rts[2].errored
+
+    @test_throws ArgumentError roots(f, interval(-10, 10) ; bisect_on_error = false)
+end

--- a/test/roots.jl
+++ b/test/roots.jl
@@ -374,7 +374,7 @@ end
 end
 
 @testset "Bisect on error" begin
-    f(x) = x == 1 ? error() : x
+    f(x) = (x < 1 ? x : x^2)
     
     rts = roots(f, interval(-10, 10))
     @test length(rts) == 2
@@ -386,5 +386,9 @@ end
     @test rts[2].convergence == :tolerance
     @test rts[2].errored
 
-    @test_throws ArgumentError roots(f, interval(-10, 10) ; bisect_on_error = false)
+    @test_throws IntervalArithmetic.InconclusiveBooleanOperation roots(f, interval(-10, 10) ; ignored_errors = [])
+
+    g(x) = (x < 1 ? x : error())
+    rts = roots(g, interval(-10, 10) ; ignored_errors = [ErrorException, IntervalArithmetic.InconclusiveBooleanOperation])
+    @test any(isunique, rts)
 end

--- a/test/roots.jl
+++ b/test/roots.jl
@@ -380,11 +380,12 @@ end
     @test length(rts) == 2
     @test rts[1].status == :unique
     @test rts[1].convergence == :converged
-    @test !rts[1].errored
+    @test isnothing(rts[1].error)
 
     @test rts[2].status == :unknown
     @test rts[2].convergence == :tolerance
-    @test rts[2].errored
+    @test !isnothing(rts[2].error)
+    @test rts[2].error[1] isa IntervalArithmetic.InconclusiveBooleanOperation
 
     @test_throws IntervalArithmetic.InconclusiveBooleanOperation roots(f, interval(-10, 10) ; ignored_errors = [])
 


### PR DESCRIPTION
Fix #232 

By default, with this PR, errors are ignored, and the corresponding regions are bisected further, in the hope that by reducing them, the error will go away.

This can be disable by setting the new option `bisect_on_error` to false.

Whether an error occurred, and why does a root stop being processed are both stored in the Root object, which allows to give more information at the end of the root search.

With this PR, the following works:

```julia
using IntervalArithmetic, IntervalRootFinding
using LinearAlgebra
using StaticArrays
using IntervalArithmetic.Symbols

function one_root()
    p(t, p0::AbstractVector, d::AbstractVector) = p0 .+ d .* t

    f(t) = norm(p(t, SVector(-2.0, 0.0, 0.0), SVector(1.0, 0.0, 0.0))) - 1.0

    roots(f, 0.0 .. 10)
end
```

Resulting in
```julia
julia> one_root()
3-element Vector{Root{Interval{Float64}}}:
 Root([1.0, 1.0]_com_NG, :unique)
 Root([2.0, 2.0]_com, :unknown)
    Not converged: region size smaller than the tolerance
    Warning: an error was encountered during computation
 Root([3.0, 3.0]_com_NG, :unique)
```

Doc and tests are missing and will come soon.

@brianguenter Does it look like a fine solution to your issue?