### PR TITLE
Better iteration state

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-BranchAndPrune = "0.2.1"
+BranchAndPrune = "0.2.2"
 ForwardDiff = "0.10, 1"
 InteractiveUtils = "1.10.0"
 IntervalArithmetic = "1.0.3"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,7 +29,6 @@ julia> using IntervalArithmetic, IntervalArithmetic.Symbols, IntervalRootFinding
 julia> rts = roots(x -> x^2 - 2x, 0..10)
 2-element Vector{Root{Interval{Float64}}}:
  Root([0.0, 3.73848e-8]_com_NG, :unknown)
-    Not converged: region size smaller than the tolerance
  Root([2.0, 2.0]_com_NG, :unique)
 ```
 
@@ -54,7 +53,7 @@ and can be either of
 However, there are several known situations where the uniqueness
 (and existence) of a solution can never be determined
 by the interval algorithms used in the package:
-  - If the function used error at for specific intervals
+  - If the function errors for specific intervals
     (for example if comparison operators like `==` and `<` are used);
   - If the solution is on the boundary of the interval (as in the previous example);
   - If the derivative of the solution is zero at the solution.
@@ -72,9 +71,7 @@ julia> roots(g, -10..10)
 4-element Vector{Root{Interval{Float64}}}:
  Root([-1.73205, -1.73205]_com_NG, :unique)
  Root([-1.41421, -1.41421]_com, :unknown)
-    Not converged: region size smaller than the tolerance
  Root([1.41421, 1.41421]_com, :unknown)
-    Not converged: region size smaller than the tolerance
  Root([1.73205, 1.73205]_com_NG, :unique)
 ```
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -55,7 +55,7 @@ but will not change the resulting tree,
 unless the maximal number of iterations is reached.
 
 Two strategies are currently available: a breadth-first strategy (process all regions before processing a sub-region);
-and a depth-first strategy (immediatly process the sub-regions of the last processed region).
+and a depth-first strategy (immediately process the sub-regions of the last processed region).
 
 Usually, the breadth-first strategy (default) is preferred,
 as the depth-first strategy may get "stuck" on a single point with a singularity,
@@ -82,7 +82,7 @@ RootProblem
   Contractor: Newton
   Function: f
   Search region: [-10.0, 10.0]_com
-  Search order: BranchAndPrune.BreadthFirst
+  Search order: BreadthFirst
   Absolute tolerance: 1.0e-7
   Relative tolerance: 0.0
   Maximum iterations: 100000
@@ -90,28 +90,31 @@ RootProblem
 
 julia> state = nothing   # stores current state of the search, so that it will be available outside of the loop
 
-julia> for outer state in problem
-           state.iteration == 15 && break  # stop at iteration 15
+julia> for s in problem
+           global state = s
+           state.iteration == 15 && break
        end
 
-julia> state.tree
-Branching
-└─ Branching
-   ├─ Branching
-   │  ├─ Branching
-   │  │  ├─ (:working, Root([-10.0, -8.78861]_com, :unknown)
-   │  │  │      Not converged: the root is still being processed)
-   │  │  └─ (:working, Root([-8.78861, -7.55814]_com, :unknown)
-   │  │         Not converged: the root is still being processed)
-   │  └─ (:final, Root([-6.28131, -6.28131]_com, :unique))
-   └─ Branching
-      ├─ (:working, Root([-5.07782, -3.84735]_com, :unknown)
-      │      Not converged: the root is still being processed)
-      └─ (:working, Root([-3.84735, -2.5975]_com, :unknown)
-             Not converged: the root is still being processed)
+julia> state
+SearchState{BreadthFirst{Root{Interval{Float64}}}, Root{Interval{Float64}}}
+  iteration: 15
+  5 regions being processed
+    Root([-0.078125, 1.15234]_com, :unknown)
+    Root([-3.84735, -2.5975]_com, :unknown)
+    Root([-5.07782, -3.84735]_com, :unknown)
+    Root([-8.78861, -7.55814]_com, :unknown)
+    Root([-10.0, -8.78861]_com, :unknown)
+  1 finalized regions
+    Root([-6.28131, -6.28131]_com, :unique)
+
 ```
 
 The elements of the iteration are `SearchState` from the `BranchAndPrune.jl` package.
-In the example, we show the tree that get constructed during the search,
-which, at iteration 15, has found one root and have 4 regions of unknown status
-to process.
+
+The roots being processed can be accessed with `unfinished_roots(state)`
+and the finalized one with `finished_roots(state)`,
+while `roots(state)` return a list containing both.
+
+See `examples/closest_to_zero.jl` for a more advanced example,
+which shows how you can find the root that is closest to zero
+and immediately terminate the search.

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -17,21 +17,6 @@ When `roots` is called, it performs a **branch-and-bound** search, that is, it i
 
 At some point all regions will either have a determined status or be smaller than the tolerance, and the algorithm will halt and return all stored roots.
 
-## Tree representation
-
-A branch-and-bound search can be naturally represented as a binary tree: each leaf contains a region and its status and each node represents a bisection. If the tree is known, the topology of the whole search can be reconstructed. There is however a point not determined by the tree.
-
-The branch and bound algorithm used by the `roots` function builds this tree and at the end collect all leaves containing a region with status either `:unknown` or `:unique`. We see below how to access the tree.
-
-## Search strategy
-
-While the tree representation is sufficient to know the topology of the search, it does not determine the order in which leaves are processed during the search.
-This has an influence on how the tree is created and the amount of memory used, but will not change the resulting tree,
-unless the maximal number of limitation is reached.
-
-Two strategies are currently available: a breadth-first strategy (leaves closer to the root of the tree are processed first);
-and a depth-first strategy (leaves further away from the root are processed first).
-
 ## Contractors
 
 To determine the status of a region, the algorithm uses so-called *contractors*.
@@ -51,15 +36,41 @@ julia> contract(Newton, sin, cos, Root(2 ± 0.001, :unknown))
 Root([1.999, 2.001]_com, :empty)
 ```
 
+While it is the fastest and doesn't require derivatives,
+`Bisection` can never prove the existence or unicity of a root.
+
+## Tree representation
+
+A branch-and-bound search can be naturally represented as a binary tree: each leaf contains a region and its status and each node represents a bisection. If the tree is known, the topology of the whole search can be reconstructed. There is however a point not determined by the tree.
+
+The branch and bound algorithm used by the `roots` function builds this tree
+and at the end collect all leaves containing a region with status either `:unknown` or `:unique`.
+
+## Search strategy
+
+While the tree representation is sufficient to know the topology of the search,
+it does not determine the order in which leaves are processed during the search.
+This has an influence on how the tree is created and the amount of memory used,
+but will not change the resulting tree,
+unless the maximal number of iterations is reached.
+
+Two strategies are currently available: a breadth-first strategy (process all regions before processing a sub-region);
+and a depth-first strategy (immediatly process the sub-regions of the last processed region).
+
+Usually, the breadth-first strategy (default) is preferred,
+as the depth-first strategy may get "stuck" on a single point with a singularity,
+until either the tolerance or the maximum number of iterations is reached.
+
 ## RootProblem and search object
 
 The parameters of a search are represented by a `RootProblem` object
 that has the same signature as the `roots` function.
 
 The `RootProblem` can be iterated to perform the search of the roots,
-for example to log information at each iteration.
+to log information, introduce an early stop criterion,
+or even modify the iteration state.
 
-For example, the following stops the search after 15 iterations and
+The follow example stops the search after 15 iterations and
 shows the state of the search at that point.
 
 ```jldoctest
@@ -77,11 +88,10 @@ RootProblem
   Maximum iterations: 100000
   Ignored errors: DataType[IntervalArithmetic.InconclusiveBooleanOperation]
 
-julia> state = nothing   # stores current state of the search
+julia> state = nothing   # stores current state of the search, so that it will be available outside of the loop
 
-julia> for (k, s) in enumerate(problem)
-           global state = s
-           k == 15 && break  # stop at iteration 15
+julia> for outer state in problem
+           state.iteration == 15 && break  # stop at iteration 15
        end
 
 julia> state.tree
@@ -101,8 +111,7 @@ Branching
              Not converged: the root is still being processed)
 ```
 
-The elements of the iteration are `SearchState` from the `BranchAndPrune.jl`
-package.
+The elements of the iteration are `SearchState` from the `BranchAndPrune.jl` package.
 In the example, we show the tree that get constructed during the search,
 which, at iteration 15, has found one root and have 4 regions of unknown status
 to process.

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -28,7 +28,6 @@ julia> roots(log, -2..2 ; contractor = Krawczyk)
 julia> roots(log, -2..2 ; contractor = Bisection)
 1-element Vector{Root{Interval{Float64}}}:
  Root([1.0, 1.0]_com, :unknown)
-    Not converged: region size smaller than the tolerance
 ```
 
 Note that as shown in the example, the `log` function does not complain about being given an interval going outside of its domain. While this may be surprising, this is the expected behavior and no root will ever be found outside the domain of a function.
@@ -169,9 +168,6 @@ julia> roots(f, -10 .. 10)
 3-element Vector{Root{Interval{Float64}}}:
  Root([0.0, 0.0]_com, :unique)
  Root([2.0, 2.0]_com, :unknown)
-    Not converged: region size smaller than the tolerance
-    Warning: error encountered during computation (use showerror(root.error) to see the whole stacktrace)
-      InconclusiveBooleanOperation: The operation `[2.0, 2.0]_com_NG < [2.0, 2.0]_com` cannot be determined unambiguously. See the documentation for more information. See also `strictprecedes`.
  Root([7.0, 7.0]_com_NG, :unique)
 ```
 

--- a/examples/closest_to_zero.jl
+++ b/examples/closest_to_zero.jl
@@ -3,22 +3,44 @@ using IntervalRootFinding
 
 f(x) = sin(1/(x + 0.5))
 
-# TODO Explain what is going on here
-# Stop when the first (guaranteed) root is found
+## Stop when the first (guaranteed) root is found
 pb = RootProblem(f, interval(-10, 10))
 state = nothing
 
 for s in pb
-    global state = s
+    global state = s  # Needed to access the state outside of the loop later
+    # `roots(state)` return a list of all roots actually considered
+    # Here as soon as one has the :unique status in one of the iteration,
+    # we stop the search
     any(isunique, roots(state)) && break
 end
 
-# Choose the order of processing manually
+# Show the state of the search at the end of the iterations
+# Use `roots(state)` to get the list of roots
+println(state)
+
+## Choose the order of processing manually
+# The `ChangingOrder` search order allows to choose which region
+# is processed next at each iteration
 pb = RootProblem(f, interval(-10, 10) ; search_order = ChangingOrder)
 state = nothing
 
 for s in pb
     global state = s
     any(isunique, roots(state)) && break
-    state.search_order.next = argmin(mig.(unconverged_roots(state)))
+    # `unconverged_roots(state)` return the set of roots that have not yet been finalized
+    # We need to choose one of them to be processed at the next iteration
+    rts = unconverged_roots(state)
+    # `mig` return the smallest distance from a member of the interval to zero
+    # Therefore the minimal value of `mig` corresponds to the interval closest to zero
+    next = argmin(mig.(rts))
+    # Use the index to set the next region that should be processed
+    set_next!(state.search_order, next)
 end
+
+# Show the state of the search at the end of the iterations
+# We can see that there are no unprocessed region closest to zero than the found root!
+println(state)
+
+# Note that `ChangingOrder` is not optimized,
+# defining a new `SearchOrder` may be better in some case

--- a/examples/closest_to_zero.jl
+++ b/examples/closest_to_zero.jl
@@ -3,10 +3,22 @@ using IntervalRootFinding
 
 f(x) = sin(1/(x + 0.5))
 
+# TODO Explain what is going on here
+# Stop when the first (guaranteed) root is found
 pb = RootProblem(f, interval(-10, 10))
 state = nothing
 
 for s in pb
     global state = s
-    any(isunique, state.roots) && break
+    any(isunique, roots(state)) && break
+end
+
+# Choose the order of processing manually
+pb = RootProblem(f, interval(-10, 10) ; search_order = ChangingOrder)
+state = nothing
+
+for s in pb
+    global state = s
+    any(isunique, roots(state)) && break
+    state.search_order.next = argmin(mig.(unconverged_roots(state)))
 end

--- a/examples/closest_to_zero.jl
+++ b/examples/closest_to_zero.jl
@@ -1,0 +1,12 @@
+using IntervalArithmetic
+using IntervalRootFinding
+
+f(x) = sin(1/(x + 0.5))
+
+pb = RootProblem(f, interval(-10, 10))
+state = nothing
+
+for s in pb
+    global state = s
+    any(isunique, state.roots) && break
+end

--- a/src/IntervalRootFinding.jl
+++ b/src/IntervalRootFinding.jl
@@ -4,7 +4,7 @@ using Reexport
 @reexport using IntervalArithmetic
 using IntervalArithmetic.Symbols
 
-using BranchAndPrune
+@reexport using BranchAndPrune
 using ForwardDiff
 using ForwardDiff: derivative, jacobian
 using InteractiveUtils
@@ -14,7 +14,6 @@ using LinearAlgebra
 
 import Base: ⊆, show, big, \
 
-export BreadthFirst, DepthFirst, ChangingOrder
 export derivative, jacobian
 
 include("region.jl")
@@ -26,7 +25,7 @@ export Root, isunique, root_status, root_region
 
 include("roots.jl")
 export roots, converged_roots, unconverged_roots
-export RootProblem, RootSearchState 
+export RootProblem
 
 include("contractors.jl")
 export Bisection, Newton, Krawczyk, contract

--- a/src/IntervalRootFinding.jl
+++ b/src/IntervalRootFinding.jl
@@ -14,6 +14,7 @@ using LinearAlgebra
 
 import Base: ⊆, show, big, \
 
+export BreadthFirst, DepthFirst, ChangingOrder
 export derivative, jacobian
 
 include("region.jl")
@@ -24,7 +25,8 @@ include("root_object.jl")
 export Root, isunique, root_status, root_region
 
 include("roots.jl")
-export roots, RootProblem
+export roots, converged_roots, unconverged_roots
+export RootProblem, RootSearchState 
 
 include("contractors.jl")
 export Bisection, Newton, Krawczyk, contract

--- a/src/root_object.jl
+++ b/src/root_object.jl
@@ -57,6 +57,10 @@ isunique(rt::Root{T}) where {T} = (rt.status == :unique)
 
 function show(io::IO, rt::Root)
     print(io, "Root($(rt.region), :$(rt.status))")
+end
+
+function show(io::IO, ::MIME"text/plain", rt::Root)
+    show(io, rt)
     if rt.status == :unknown
         if rt.convergence == :tolerance
             print(io, "\n    Not converged: region size smaller than the tolerance")

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -210,14 +210,13 @@ see [`RootProblem`](@ref).
 """
 function roots(f, region ; kwargs...)
     problem = RootProblem(f, region ; kwargs...)
-    search = root_search(problem)
     state = nothing
 
-    for outer state in search end
+    for outer state in problem end
 
     result = BranchAndPrune.BranchAndPruneResult(
         state.search_order,
-        search.initial_region,
+        problem.region,
         state.tree
     )
 

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -118,33 +118,9 @@ Base.show(io::IO, pb::RootProblem) = print(io, """
       Ignored errors: $(pb.ignored_errors)"""
 )
 
-# TODO Document
-# TODO Simplify, only the state is actually needed... Just use it with more methods ?
-struct RootSearchState{R <: Root, S <: SearchOrder, B <: BranchAndPruneSearch}
-    iteration::Int
-    roots::Vector{R}
-    state::BranchAndPrune.SearchState{S, R}
-    search::B
-end
-
-roots(state::RootSearchState) = [leaf.region for leaf in BranchAndPrune.Leaves(state.tree)]
-converged_roots(state::RootSearchState) = [leaf.region for leaf in BranchAndPrune.Leaves(state.tree) if leaf.status == :final]
-unconverged_roots(state::RootSearchState) = [leaf.region for leaf in state.search_order.working_leaves]
-
-function Base.getproperty(state::RootSearchState, name::Symbol)
-    hasfield(RootSearchState, name) && return getfield(state, name)
-    hasfield(BranchAndPrune.SearchState, name) && return getfield(state.state, name)
-end
-
-function Base.show(io::IO, state::RootSearchState)
-    print(io, """RootSearchState
-      iteration: $(state.iteration)
-      roots:
-    """) 
-    for rt in state.roots
-        println(io, "    $rt")
-    end
-end
+roots(state::SearchState) = regions(state)
+converged_roots(state::SearchState) = finished_regions(state)
+unconverged_roots(state::SearchState) = unfinished_regions(state)
 
 function Base.iterate(root_problem::RootProblem, state = nothing)
     if isnothing(state)
@@ -157,13 +133,7 @@ function Base.iterate(root_problem::RootProblem, state = nothing)
     isnothing(bp_iteration) && return nothing
     bp_search_state = bp_iteration[2]
     bp_search_state.iteration > root_problem.max_iteration && return nothing
-    state = RootSearchState(
-        bp_search_state.iteration,
-        [node.region for node in BranchAndPrune.Leaves(bp_search_state.tree)],
-        bp_search_state,
-        search
-    )
-    return state, (search, bp_search_state)
+    return bp_search_state, (search, bp_search_state)
 end
    
 function bisect_region(r::Root, α)

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -118,11 +118,22 @@ Base.show(io::IO, pb::RootProblem) = print(io, """
       Ignored errors: $(pb.ignored_errors)"""
 )
 
+# TODO Document
+# TODO Simplify, only the state is actually needed... Just use it with more methods ?
 struct RootSearchState{R <: Root, S <: SearchOrder, B <: BranchAndPruneSearch}
     iteration::Int
     roots::Vector{R}
     state::BranchAndPrune.SearchState{S, R}
     search::B
+end
+
+roots(state::RootSearchState) = [leaf.region for leaf in BranchAndPrune.Leaves(state.tree)]
+converged_roots(state::RootSearchState) = [leaf.region for leaf in BranchAndPrune.Leaves(state.tree) if leaf.status == :final]
+unconverged_roots(state::RootSearchState) = [leaf.region for leaf in state.search_order.working_leaves]
+
+function Base.getproperty(state::RootSearchState, name::Symbol)
+    hasfield(RootSearchState, name) && return getfield(state, name)
+    hasfield(BranchAndPrune.SearchState, name) && return getfield(state.state, name)
 end
 
 function Base.show(io::IO, state::RootSearchState)

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -128,6 +128,7 @@ function Base.iterate(root_problem::RootProblem, state = nothing)
     end
     isnothing(iteration) && return nothing
     value, new_search_state = iteration
+    new_search_state.iteration > root_problem.max_iteration && return nothing
     return value, (search, new_search_state)
 end
    
@@ -206,17 +207,14 @@ see [`RootProblem`](@ref).
 function roots(f, region ; kwargs...)
     problem = RootProblem(f, region ; kwargs...)
     search = root_search(problem)
-    endstate = nothing
+    state = nothing
 
-    for (iter, state) in enumerate(search)
-        endstate = state
-        iter >= problem.max_iteration && break
-    end
+    for outer state in search end
 
     result = BranchAndPrune.BranchAndPruneResult(
-        endstate.search_order,
+        state.search_order,
         search.initial_region,
-        endstate.tree
+        state.tree
     )
 
     rts = vcat(result.final_regions, result.unfinished_regions)

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -118,18 +118,41 @@ Base.show(io::IO, pb::RootProblem) = print(io, """
       Ignored errors: $(pb.ignored_errors)"""
 )
 
+struct RootSearchState{R <: Root, S <: SearchOrder, B <: BranchAndPruneSearch}
+    iteration::Int
+    roots::Vector{R}
+    state::BranchAndPrune.SearchState{S, R}
+    search::B
+end
+
+function Base.show(io::IO, state::RootSearchState)
+    print(io, """RootSearchState
+      iteration: $(state.iteration)
+      roots:
+    """) 
+    for rt in state.roots
+        println(io, "    $rt")
+    end
+end
+
 function Base.iterate(root_problem::RootProblem, state = nothing)
     if isnothing(state)
         search = root_search(root_problem)
-        iteration = iterate(search)
+        bp_iteration = iterate(search)
     else
         search, search_state = state
-        iteration = iterate(search, search_state)
+        bp_iteration = iterate(search, search_state)
     end
-    isnothing(iteration) && return nothing
-    value, new_search_state = iteration
-    new_search_state.iteration > root_problem.max_iteration && return nothing
-    return value, (search, new_search_state)
+    isnothing(bp_iteration) && return nothing
+    bp_search_state = bp_iteration[2]
+    bp_search_state.iteration > root_problem.max_iteration && return nothing
+    state = RootSearchState(
+        bp_search_state.iteration,
+        [node.region for node in BranchAndPrune.Leaves(bp_search_state.tree)],
+        bp_search_state,
+        search
+    )
+    return state, (search, bp_search_state)
 end
    
 function bisect_region(r::Root, α)


### PR DESCRIPTION
Fix #206 and #169 

Introduce a new API to access the iteration state, when iterating over a RootProblem. See `examples/closest_to_zero.jl` for an example that implement the problem proposed in #169.

New features:
- Better printing of everything
- `roots(state)`, `finished_roots(state)` and `unfinished_roots(state)` to examine the roots during iteration (respectively, all roots, the roots still being processed, and the roots that are considered final -- either because they are converged of fall below the given tolerance).
- `ChangingOrder` search order (implemented in BranchAndPrune.jl), which allow to modify the order of iteration on the fly (see example).

```julia
# The `ChangingOrder` search order allows to choose which region
# is processed next at each iteration
pb = RootProblem(f, interval(-10, 10) ; search_order = ChangingOrder)
state = nothing

for s in pb
    global state = s
    any(isunique, roots(state)) && break
    # `unconverged_roots(state)` return the set of roots that have not yet been finalized
    # We need to choose one of them to be processed at the next iteration
    rts = unconverged_roots(state)
    # `mig` return the smallest distance from a member of the interval to zero
    # Therefore the minimal value of `mig` corresponds to the interval closest to zero
    next = argmin(mig.(rts))
    # Use the index to set the next region that should be processed
    set_next!(state.search_order, next)
end
```

TODO
- [x] Fix doctests
- [x] Specific tests for the iteration state
- [x] Update documentation