### PR TITLE
More beautiful display of :unknown 

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,6 +29,7 @@ julia> using IntervalArithmetic, IntervalArithmetic.Symbols, IntervalRootFinding
 julia> rts = roots(x -> x^2 - 2x, 0..10)
 2-element Vector{Root{Interval{Float64}}}:
  Root([0.0, 3.73951e-8]_com_NG, :unknown)
+ └ Not converged: region size smaller than the tolerance
  Root([1.99999, 2.00001]_com_NG, :unique)
 ```
 
@@ -71,7 +72,9 @@ julia> roots(g, -10..10)
 4-element Vector{Root{Interval{Float64}}}:
  Root([-1.73206, -1.73205]_com_NG, :unique)
  Root([-1.41422, -1.41421]_com_NG, :unknown)
+ └ Not converged: region size smaller than the tolerance
  Root([1.41421, 1.41422]_com_NG, :unknown)
+ └ Not converged: region size smaller than the tolerance
  Root([1.73205, 1.73206]_com_NG, :unique)
 ```
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -100,10 +100,15 @@ SearchState{BreadthFirst{Root{Interval{Float64}}}, Root{Interval{Float64}}}
   iteration: 15
   5 regions being processed
     Root([-0.078125, 1.15235]_com, :unknown)
+ └ Not converged: the root is still being processed
     Root([-3.84735, -2.5975]_com, :unknown)
+ └ Not converged: the root is still being processed
     Root([-5.07782, -3.84734]_com, :unknown)
+ └ Not converged: the root is still being processed
     Root([-8.78861, -7.55813]_com, :unknown)
+ └ Not converged: the root is still being processed
     Root([-10.0, -8.7886]_com, :unknown)
+ └ Not converged: the root is still being processed
   1 finalized regions
     Root([-6.28132, -6.28131]_com, :unique)
 

--- a/docs/src/roots.md
+++ b/docs/src/roots.md
@@ -28,6 +28,7 @@ julia> roots(log, -2..2 ; contractor = Krawczyk)
 julia> roots(log, -2..2 ; contractor = Bisection)
 1-element Vector{Root{Interval{Float64}}}:
  Root([0.999999, 1.00001]_com, :unknown)
+ └ Not converged: region size smaller than the tolerance
 ```
 
 Note that as shown in the example, the `log` function does not complain about being given an interval going outside its domain. While this may be surprising, this is the expected behavior and no root will ever be found outside the domain of a function.
@@ -168,6 +169,9 @@ julia> roots(f, -10 .. 10)
 3-element Vector{Root{Interval{Float64}}}:
  Root([0.0, 0.0]_com, :unique)
  Root([1.99999, 2.00001]_com, :unknown)
+ ├ Not converged: region size smaller than the tolerance
+ ├ Warning: error encountered during computation (use showerror(root.error) to see the whole stacktrace)
+ └ InconclusiveBooleanOperation: The operation `[2.0, 2.0]_com_NG < [1.99999, 2.00001]_com` cannot be determined unambiguously. See the documentation for more information. See also `strictprecedes`.
  Root([7.0, 7.0]_com_NG, :unique)
 ```
 

--- a/src/root_object.jl
+++ b/src/root_object.jl
@@ -59,18 +59,20 @@ function show(io::IO, rt::Root)
     print(io, "Root($(rt.region), :$(rt.status))")
 
     if !get(io, :compact, false) && rt.status == :unknown
+        connector = isnothing(rt.error) ? "└" : "├"
+        
         if rt.convergence == :tolerance
-            print(io, "\n    Not converged: region size smaller than the tolerance")
+            print(io, "\n $connector Not converged: region size smaller than the tolerance")
         elseif rt.convergence == :max_iterartion 
-            print(io, "\n    Not converged: reached maximal number of iterations")
+            print(io, "\n $connector Not converged: reached maximal number of iterations")
         elseif rt.convergence == :none
-            print(io, "\n    Not converged: the root is still being processed")
+            print(io, "\n $connector Not converged: the root is still being processed")
         else
-            print(io, "\n    Not converged: unknown reason $(rt.convergence)")
+            print(io, "\n $connector Not converged: unknown reason $(rt.convergence)")
         end
 
         if !isnothing(rt.error)
-            print(io, "\n    Warning: error encountered during computation (use showerror(root.error) to see the whole stacktrace)\n      ")
+            print(io, "\n ├ Warning: error encountered during computation (use showerror(root.error) to see the whole stacktrace)\n └ ")
             showerror(io, rt.error[1])
         end
     end

--- a/src/root_object.jl
+++ b/src/root_object.jl
@@ -57,11 +57,8 @@ isunique(rt::Root{T}) where {T} = (rt.status == :unique)
 
 function show(io::IO, rt::Root)
     print(io, "Root($(rt.region), :$(rt.status))")
-end
 
-function show(io::IO, ::MIME"text/plain", rt::Root)
-    show(io, rt)
-    if rt.status == :unknown
+    if !get(io, :compact, false) && rt.status == :unknown
         if rt.convergence == :tolerance
             print(io, "\n    Not converged: region size smaller than the tolerance")
         elseif rt.convergence == :max_iterartion 


### PR DESCRIPTION
As discussed in the JuliaInterval call, this PR reintroduces showing more information for `:unknown` roots in vectors, with fancy connector to group the information.

However, this information is still hidden if the IOContext is `:compact`, like for matrices:

```julia
julia> f(x) = (x < 1) ? x : (x - 2)^2 * (x - 3)
f (generic function with 1 method)

julia> rts = roots(f, interval(-5, 5))
4-element Vector{Root{Interval{Float64}}}:
 Root([0.0, 0.0]_com, :unique)
 Root([1.0, 1.0]_com, :unknown)
 ├ Not converged: region size smaller than the tolerance
 ├ Warning: error encountered during computation (use showerror(root.error) to see the whole stacktrace)
 └ InconclusiveBooleanOperation: The operation `[1.0, 1.0]_com < [1.0, 1.0]_com_NG` cannot be determined unambiguously. See the documentation for more information. See also `strictprecedes`.
 Root([2.0, 2.0]_com_NG, :unknown)
 └ Not converged: region size smaller than the tolerance
 Root([3.0, 3.0]_com_NG, :unique)

julia> reshape(rts, 2, 2)
2×2 Matrix{Root{Interval{Float64}}}:
 Root([0.0, 0.0]_com, :unique)   Root([2.0, 2.0]_com_NG, :unknown)
 Root([1.0, 1.0]_com, :unknown)  Root([3.0, 3.0]_com_NG, :unique)
```

@dpsanders @OlivierHnt 